### PR TITLE
Add support for custom publish functions

### DIFF
--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -13,8 +13,10 @@ const options =
 
 let unblockEnabled = options.unblock;
 
+let publish = Meteor.publish;
+
 function publishComposite(name, options, config) {
-    return Meteor.publish(name, function publish(...args) {
+    return publish(name, function publish(...args) {
         if ((unblockEnabled && (!config || config.unblock !== false))
             || (config && config.unblock)) {
             if (!this.unblock) {
@@ -64,8 +66,12 @@ function prepareOptions(options, args) {
     return preparedOptions;
 }
 
+function setPublishFunction(newPublish) {
+    publish = newPublish;
+}
 
 export {
     enableDebugLogging,
     publishComposite,
+    setPublishFunction,
 };

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
     name: 'pathable:publish-composite',
     summary: 'Publish a set of related documents from multiple collections with a reactive join',
-    version: '1.8.3',
+    version: '1.8.4',
     git: 'https://github.com/pathable/meteor-publish-composite.git',
 });
 


### PR DESCRIPTION
Adds the `setPublishFunction` function to change the publish function `publishComposite` uses, in order to make it possible to wrap it on app code.